### PR TITLE
Implementation of khr_punctual_lights extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ exe.addModule("zgltf", zgltf.module(b));
 - [ ] Morth targets
 - [ ] Extras data
 - [ ] glTF writer
-- [ ] glTF extensions
+
+Also, we supports some glTF extensions:
+
+- [x] khr_lights_punctual
 
 ## Contributing to the project
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -460,12 +460,9 @@ fn parseGltfJson(self: *Self, gltf_json: []const u8) !void {
                 }
             }
 
-            if (object.get("extensions")) |extensions|
-            {
-                if (extensions.Object.get("KHR_lights_punctual")) |lights_punctual|
-                {
-                    if (lights_punctual.Object.get("light")) |light|
-                    {
+            if (object.get("extensions")) |extensions| {
+                if (extensions.Object.get("KHR_lights_punctual")) |lights_punctual| {
+                    if (lights_punctual.Object.get("light")) |light| {
                         node.light = @intCast(Index, light.Integer);
                     }
                 }
@@ -1164,34 +1161,26 @@ fn parseGltfJson(self: *Self, gltf_json: []const u8) !void {
         }
     }
 
-    if (gltf.root.Object.get("extensions")) |extensions|
-    {
-        if (extensions.Object.get("KHR_lights_punctual")) |lights_punctual|
-        {
-            if (lights_punctual.Object.get("lights")) |lights|
-            {
-                for (lights.Array.items) |item|
-                {
+    if (gltf.root.Object.get("extensions")) |extensions| {
+        if (extensions.Object.get("KHR_lights_punctual")) |lights_punctual| {
+            if (lights_punctual.Object.get("lights")) |lights| {
+                for (lights.Array.items) |item| {
                     const object: std.json.ObjectMap = item.Object;
 
-                    var light = Light {
+                    var light = Light{
                         .name = null,
                         .type = undefined,
                         .range = std.math.inf(f32),
                         .spot = null,
                     };
 
-                    if (object.get("name")) |name|
-                    {
+                    if (object.get("name")) |name| {
                         light.name = try alloc.dupe(u8, name.String);
                     }
 
-                    if (object.get("color")) |color|
-                    {
-                        for (color.Array.items, 0..) |component, i|
-                        {
-                            switch (component)
-                            {
+                    if (object.get("color")) |color| {
+                        for (color.Array.items, 0..) |component, i| {
+                            switch (component) {
                                 .Float => |float| {
                                     light.color[i] = @floatCast(f32, float);
                                 },
@@ -1203,10 +1192,8 @@ fn parseGltfJson(self: *Self, gltf_json: []const u8) !void {
                         }
                     }
 
-                    if (object.get("intensity")) |intensity|
-                    {
-                        switch (intensity)
-                        {
+                    if (object.get("intensity")) |intensity| {
+                        switch (intensity) {
                             .Float => |float| {
                                 light.intensity = @floatCast(f32, float);
                             },
@@ -1214,20 +1201,17 @@ fn parseGltfJson(self: *Self, gltf_json: []const u8) !void {
                                 light.intensity = @intToFloat(f32, integer);
                             },
                             else => unreachable,
-                        }                        
+                        }
                     }
 
-                    if (object.get("type")) |@"type"|
-                    {
+                    if (object.get("type")) |@"type"| {
                         const light_type = std.meta.stringToEnum(LightType, @"type".String) orelse unreachable;
 
                         light.type = light_type;
                     }
 
-                    if (object.get("range")) |range|
-                    {
-                        switch (range)
-                        {
+                    if (object.get("range")) |range| {
+                        switch (range) {
                             .Float => |float| {
                                 light.range = @floatCast(f32, float);
                             },
@@ -1235,17 +1219,14 @@ fn parseGltfJson(self: *Self, gltf_json: []const u8) !void {
                                 light.range = @intToFloat(f32, integer);
                             },
                             else => unreachable,
-                        }  
+                        }
                     }
 
-                    if (object.get("spot")) |spot|
-                    {
+                    if (object.get("spot")) |spot| {
                         light.spot = .{};
 
-                        if (spot.Object.get("innerConeAngle")) |inner_cone_angle|
-                        {
-                            switch (inner_cone_angle)
-                            {
+                        if (spot.Object.get("innerConeAngle")) |inner_cone_angle| {
+                            switch (inner_cone_angle) {
                                 .Float => |float| {
                                     light.spot.?.inner_cone_angle = @floatCast(f32, float);
                                 },
@@ -1256,10 +1237,8 @@ fn parseGltfJson(self: *Self, gltf_json: []const u8) !void {
                             }
                         }
 
-                        if (spot.Object.get("outerConeAngle")) |outer_cone_angle|
-                        {
-                            switch (outer_cone_angle)
-                            {
+                        if (spot.Object.get("outerConeAngle")) |outer_cone_angle| {
+                            switch (outer_cone_angle) {
                                 .Float => |float| {
                                     light.spot.?.outer_cone_angle = @floatCast(f32, float);
                                 },
@@ -1538,8 +1517,7 @@ test "gltf.getDataFromBufferView" {
     }
 }
 
-test "gltf.parse (lights)"
-{
+test "gltf.parse (lights)" {
     const allocator = std.testing.allocator;
     const expect = std.testing.expect;
     const expectEqual = std.testing.expectEqual;

--- a/src/main.zig
+++ b/src/main.zig
@@ -50,6 +50,7 @@ pub const TargetProperty = types.TargetProperty;
 pub const Asset = types.Asset;
 pub const LightType = types.LightType;
 pub const Light = types.Light;
+pub const LightSpot = types.LightSpot;
 
 pub const Data = struct {
     asset: Asset,

--- a/src/types.zig
+++ b/src/types.zig
@@ -463,22 +463,41 @@ pub const Camera = struct {
     },
 };
 
+///Specifies the light type
 pub const LightType = enum {
+    ///Directional lights act as though they are infinitely far away and emit light in the direction of the local -z axis.
+    ///This light type inherits the orientation of the node that it belongs to; position and scale are ignored except for their effect on the inherited node orientation.
+    ///Because it is at an infinite distance, the light is not attenuated. Its intensity is defined in lumens per metre squared, or lux (lm/m^2).
     directional,
-    point, 
+    ///Point lights emit light in all directions from their position in space; rotation and scale are ignored except for their effect on the inherited node position.
+    ///The brightness of the light attenuates in a physically correct manner as distance increases from the light's position (i.e. brightness goes like the inverse square of the distance).
+    ///Point light intensity is defined in candela, which is lumens per square radian (lm/sr).
+    point,
+    ///Spot lights emit light in a cone in the direction of the local -z axis.
+    ///The angle and falloff of the cone is defined using two numbers, the innerConeAngle and outerConeAngle.
+    ///As with point lights, the brightness also attenuates in a physically correct manner as distance increases from the light's position (i.e. brightness goes like the inverse square of the distance).
+    ///Spot light intensity refers to the brightness inside the innerConeAngle (and at the location of the light) and is defined in candela, which is lumens per square radian (lm/sr).
+    ///Engines that don't support two angles for spotlights should use outerConeAngle as the spotlight angle (leaving innerConeAngle to implicitly be 0).
     spot,
 };
 
+///A directional, point or spot light
 pub const Light = struct {
     name: ?[]const u8,
+    ///Color of the light source.
     color: [3]f32 = .{ 1, 1, 1 },
+    ///Intensity of the light source. `point` and `spot` lights use luminous intensity in candela (lm/sr) while `directional` lights use illuminance in lux (lm/m^2)
     intensity: f32 = 1,
+    ///Specifies the light type
     type: LightType,
     spot: ?LightSpot,
+    ///A distance cutoff at which the light's intensity may be considered to have reached zero.
     range: f32,
 };
 
 pub const LightSpot = struct {
+    ///Angle in radians from centre of spotlight where falloff begins.
     inner_cone_angle: f32 = 0,
+    ///Angle in radians from centre of spotlight where falloff ends.
     outer_cone_angle: f32 = std.math.pi / @as(f32, 4),
 };

--- a/src/types.zig
+++ b/src/types.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const pi = std.math.pi;
 const ArrayList = std.ArrayList;
 
 /// Index of element in data arrays.
@@ -463,41 +464,50 @@ pub const Camera = struct {
     },
 };
 
-///Specifies the light type
+/// Specifies the light type.
 pub const LightType = enum {
-    ///Directional lights act as though they are infinitely far away and emit light in the direction of the local -z axis.
-    ///This light type inherits the orientation of the node that it belongs to; position and scale are ignored except for their effect on the inherited node orientation.
-    ///Because it is at an infinite distance, the light is not attenuated. Its intensity is defined in lumens per metre squared, or lux (lm/m^2).
+    /// Directional lights act as though they are infinitely far away and emit light in the direction of the local -z axis.
+    /// This light type inherits the orientation of the node that it belongs to; position and scale are ignored
+    /// except for their effect on the inherited node orientation. Because it is at an infinite distance,
+    /// the light is not attenuated. Its intensity is defined in lumens per metre squared, or lux (lm/m^2).
     directional,
-    ///Point lights emit light in all directions from their position in space; rotation and scale are ignored except for their effect on the inherited node position.
-    ///The brightness of the light attenuates in a physically correct manner as distance increases from the light's position (i.e. brightness goes like the inverse square of the distance).
-    ///Point light intensity is defined in candela, which is lumens per square radian (lm/sr).
+    /// Point lights emit light in all directions from their position in space; rotation and scale are ignored except
+    /// for their effect on the inherited node position.
+    /// The brightness of the light attenuates in a physically correct manner as distance increases from
+    /// the light's position (i.e. brightness goes like the inverse square of the distance).
+    /// Point light intensity is defined in candela, which is lumens per square radian (lm/sr).
     point,
-    ///Spot lights emit light in a cone in the direction of the local -z axis.
-    ///The angle and falloff of the cone is defined using two numbers, the innerConeAngle and outerConeAngle.
-    ///As with point lights, the brightness also attenuates in a physically correct manner as distance increases from the light's position (i.e. brightness goes like the inverse square of the distance).
-    ///Spot light intensity refers to the brightness inside the innerConeAngle (and at the location of the light) and is defined in candela, which is lumens per square radian (lm/sr).
-    ///Engines that don't support two angles for spotlights should use outerConeAngle as the spotlight angle (leaving innerConeAngle to implicitly be 0).
+    /// Spot lights emit light in a cone in the direction of the local -z axis.
+    /// The angle and falloff of the cone is defined using two numbers, the innerConeAngle and outerConeAngle.
+    /// As with point lights, the brightness also attenuates in a physically correct manner as distance
+    /// increases from the light's position (i.e. brightness goes like the inverse square of the distance).
+    /// Spot light intensity refers to the brightness inside the innerConeAngle (and at the location of the light) and
+    /// is defined in candela, which is lumens per square radian (lm/sr).
+    ///
+    /// Engines that don't support two angles for spotlights should use outerConeAngle as the spotlight angle,
+    /// leaving innerConeAngle to implicitly be 0.
     spot,
 };
 
-///A directional, point or spot light
+/// A directional, point or spot light.
 pub const Light = struct {
     name: ?[]const u8,
-    ///Color of the light source.
+    /// Color of the light source.
     color: [3]f32 = .{ 1, 1, 1 },
-    ///Intensity of the light source. `point` and `spot` lights use luminous intensity in candela (lm/sr) while `directional` lights use illuminance in lux (lm/m^2)
+    /// Intensity of the light source. `point` and `spot` lights use luminous intensity in candela (lm/sr)
+    /// while `directional` lights use illuminance in lux (lm/m^2).
     intensity: f32 = 1,
-    ///Specifies the light type
+    /// Specifies the light type.
     type: LightType,
+    /// When a light's type is spot, the spot property on the light is required.
     spot: ?LightSpot,
-    ///A distance cutoff at which the light's intensity may be considered to have reached zero.
+    /// A distance cutoff at which the light's intensity may be considered to have reached zero.
     range: f32,
 };
 
 pub const LightSpot = struct {
-    ///Angle in radians from centre of spotlight where falloff begins.
+    /// Angle in radians from centre of spotlight where falloff begins.
     inner_cone_angle: f32 = 0,
-    ///Angle in radians from centre of spotlight where falloff ends.
-    outer_cone_angle: f32 = std.math.pi / @as(f32, 4),
+    /// Angle in radians from centre of spotlight where falloff ends.
+    outer_cone_angle: f32 = pi / @as(f32, 4),
 };

--- a/src/types.zig
+++ b/src/types.zig
@@ -44,6 +44,8 @@ pub const Node = struct {
     /// The number of array elements must match the number of morph targets
     /// of the referenced mesh. When defined, mesh mush also be defined.
     weights: ?[]usize = null,
+    ///The index of the light referenced by this node.
+    light: ?Index = null,
 };
 
 /// A buffer points to binary geometry, animation, or skins.
@@ -459,4 +461,24 @@ pub const Camera = struct {
         perspective: Perspective,
         orthographic: Orthographic,
     },
+};
+
+pub const LightType = enum {
+    directional,
+    point, 
+    spot,
+};
+
+pub const Light = struct {
+    name: ?[]const u8,
+    color: [3]f32 = .{ 1, 1, 1 },
+    intensity: f32 = 1,
+    type: LightType,
+    spot: ?LightSpot,
+    range: f32,
+};
+
+pub const LightSpot = struct {
+    inner_cone_angle: f32 = 0,
+    outer_cone_angle: f32 = std.math.pi / @as(f32, 4),
 };

--- a/test-samples/khr_lights_punctual/Lights.gltf
+++ b/test-samples/khr_lights_punctual/Lights.gltf
@@ -1,0 +1,158 @@
+{
+    "asset" : {
+        "generator" : "Khronos glTF Blender I/O v1.1.46",
+        "version" : "2.0"
+    },
+    "extensionsUsed" : [
+        "KHR_lights_punctual"
+    ],
+    "extensionsRequired" : [
+        "KHR_lights_punctual"
+    ],
+    "extensions" : {
+        "KHR_lights_punctual" : {
+            "lights" : [
+                {
+                    "color" : [
+                        1,
+                        1,
+                        1
+                    ],
+                    "intensity" : 1000,
+                    "type" : "point",
+                    "name" : "Light"
+                },
+                {
+                    "color" : [
+                        1,
+                        1,
+                        1
+                    ],
+                    "intensity" : 1000,
+                    "type" : "spot",
+                    "spot": {
+                        "innerConeAngle": 0,
+                        "outerConeAngle": 1
+                    },
+                    "name" : "Light.001"
+                },
+                {
+                    "color" : [
+                        1,
+                        1,
+                        1
+                    ],
+                    "intensity" : 1000,
+                    "type" : "directional",
+                    "name" : "Light.002"
+                }
+            ]
+        }
+    },
+    "scene" : 0,
+    "scenes" : [
+        {
+            "name" : "Scene",
+            "nodes" : [
+                1,
+                3,
+                5
+            ]
+        }
+    ],
+    "nodes" : [
+        {
+            "extensions" : {
+                "KHR_lights_punctual" : {
+                    "light" : 0
+                }
+            },
+            "name" : "Light_Orientation",
+            "rotation" : [
+                -0.7071067690849304,
+                0,
+                0,
+                0.7071067690849304
+            ]
+        },
+        {
+            "children" : [
+                0
+            ],
+            "name" : "Light",
+            "rotation" : [
+                0.16907575726509094,
+                0.7558803558349609,
+                -0.27217137813568115,
+                0.570947527885437
+            ],
+            "translation" : [
+                4.076245307922363,
+                5.903861999511719,
+                -1.0054539442062378
+            ]
+        },
+        {
+            "extensions" : {
+                "KHR_lights_punctual" : {
+                    "light" : 1
+                }
+            },
+            "name" : "Light.001_Orientation",
+            "rotation" : [
+                -0.7071067690849304,
+                0,
+                0,
+                0.7071067690849304
+            ]
+        },
+        {
+            "children" : [
+                2
+            ],
+            "name" : "Light.001",
+            "rotation" : [
+                0.16907575726509094,
+                0.7558803558349609,
+                -0.27217137813568115,
+                0.570947527885437
+            ],
+            "translation" : [
+                -3.9570322036743164,
+                1.8591556549072266,
+                -4.55197811126709
+            ]
+        },
+        {
+            "extensions" : {
+                "KHR_lights_punctual" : {
+                    "light" : 2
+                }
+            },
+            "name" : "Light.002_Orientation",
+            "rotation" : [
+                -0.7071067690849304,
+                0,
+                0,
+                0.7071067690849304
+            ]
+        },
+        {
+            "children" : [
+                4
+            ],
+            "name" : "Light.002",
+            "rotation" : [
+                0.16907575726509094,
+                0.7558803558349609,
+                -0.27217137813568115,
+                0.570947527885437
+            ],
+            "translation" : [
+                0.6759738922119141,
+                1.6738548278808594,
+                3.1679487228393555
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This is an implementation of https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_lights_punctual 

I'm not sure how you wanted to implement extensions, but for this one I've put the extension checking into the parser so that the user of the library doesn't have to check, and can just check the size of with ```gltf.data.lights.len``` or the presence of a light on a node with ```if (node.light == null)```.

And thank for for creating this great library, it's much better than using cgltf!