### PR TITLE
Add build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,16 @@
+.{
+    .name = "zgltf",
+    .version = "0.1.0",
+    .minimum_zig_version = "0.11.0",
+    .dependencies = .{},
+    .paths = .{
+        ".github",
+        ".gitignore",
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "test-samples",
+        "LICENSE",
+        "README.md",
+    },
+}


### PR DESCRIPTION
Adds a `build.zig.zon` file for use with the Zig package manager. Documentation for this file can be found [here](https://github.com/ziglang/zig/blob/master/doc/build.zig.zon.md).