### PR TITLE
Update to zig 0.14.0-dev.1409+6d2945f1f

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1281,7 +1281,7 @@ fn parseIndex(component: json.Value) usize {
 // floating numbers.
 fn parseFloat(comptime T: type, component: json.Value) T {
     const type_info = @typeInfo(T);
-    if (type_info != .Float) {
+    if (type_info != .float) {
         panic(
             "Given type '{any}' is not a floating number.",
             .{type_info},


### PR DESCRIPTION
`std.builtin.Type` fields were recently renamed to fit naming conventions: [https://github.com/ziglang/zig/pull/21225](https://github.com/ziglang/zig/pull/21225).