### PR TITLE
make Perspective aspect_ratio and zfar optional

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -499,12 +499,15 @@ fn parseGltfJson(self: *Self, gltf_json: []const u8) !void {
 
                         camera.type = .{
                             .perspective = .{
-                                .aspect_ratio = parseFloat(
+                                .aspect_ratio = if (value.get("aspectRatio")) |aspect_ratio| parseFloat(
                                     f32,
-                                    value.get("aspectRatio").?,
-                                ),
+                                    aspect_ratio,
+                                ) else null,
                                 .yfov = parseFloat(f32, value.get("yfov").?),
-                                .zfar = parseFloat(f32, value.get("zfar").?),
+                                .zfar = if (value.get("zfar")) |zfar| parseFloat(
+                                    f32,
+                                    zfar,
+                                ) else null,
                                 .znear = parseFloat(f32, value.get("znear").?),
                             },
                         };

--- a/src/types.zig
+++ b/src/types.zig
@@ -536,12 +536,12 @@ pub const Camera = struct {
     /// perspective projection matrix.
     pub const Perspective = struct {
         /// The aspect ratio of the field of view.
-        aspect_ratio: f32,
+        aspect_ratio: ?f32,
         /// The vertical field of view in radians.
         /// This value should be less than π.
         yfov: f32,
         /// The distance to the far clipping plane.
-        zfar: f32,
+        zfar: ?f32,
         /// The distance to the near clipping plane.
         znear: f32,
     };


### PR DESCRIPTION
These are optional [as per the spec](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-camera-perspective) and there's no reasonable default as their absence has special semantics