### PR TITLE
Make code compatible with zig 0.13.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = "zgltf",
     .version = "0.1.0",
-    .minimum_zig_version = "0.11.0",
+    .minimum_zig_version = "0.13.0",
     .dependencies = .{},
     .paths = .{
         ".github",

--- a/src/main.zig
+++ b/src/main.zig
@@ -1285,7 +1285,7 @@ fn parseIndex(component: json.Value) usize {
 // floating numbers.
 fn parseFloat(comptime T: type, component: json.Value) T {
     const type_info = @typeInfo(T);
-    if (type_info != .float) {
+    if (type_info != .Float) {
         panic(
             "Given type '{any}' is not a floating number.",
             .{type_info},


### PR DESCRIPTION
I want to use this library in my project that uses zig 0.13, but theres one line that makes zig build fail with the following error:
```
src/main.zig:1288:23: error: no field named 'float' in enum '@typeInfo(builtin.Type).Union.tag_type.?'
    if (type_info != .float) {
                     ~^~~~~
```
This PR fixes that.

If it's possible / necessary, I would like to see this be merged into a separate branch - something like "zig-0.13-compat". Thank you very much :)