### PR TITLE
Basic support for `EXT_texture_webp`

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1085,6 +1085,14 @@ fn parseGltfJson(self: *Self, gltf_json: []const u8) !void {
                 texture.source = parseIndex(source);
             }
 
+            if (item.object.get("extensions")) |extension| {
+                if (extension.object.get("EXT_texture_webp")) |webp| {
+                    if (webp.object.get("source")) |source| {
+                        texture.source = parseIndex(source);
+                    }
+                }
+            }
+
             if (item.object.get("sampler")) |sampler| {
                 texture.sampler = parseIndex(sampler);
             }


### PR DESCRIPTION
Spec: https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_texture_webp/README.md

If `EXT_texture_webp` is specified use it as a texture source.

Note: this does not handle the fallback case of having both a JPG/PNG source image *and* a WebP source simultaneously.

The motivation is that WebP has roughly 25-30% better compression than JPG/PNG. And if you use WebP textures in Blender the exported glTF file uses this extension.