### PR TITLE
place Gltf type in own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note: The main branch is for the latest Zig release (0.15.1).
 
 ```zig
 const std = @import("std");
-const Gltf = @import("zgltf");
+const Gltf = @import("zgltf").Gltf;
 
 const allocator = std.heap.page_allocator;
 const print = std.debug.print;
@@ -31,7 +31,7 @@ pub fn main() void {
     );
     defer allocator.free(buf);
 
-    var gltf = Self.init(allocator);
+    var gltf = Gltf.init(allocator);
     defer gltf.deinit();
 
     try gltf.parse(buf);
@@ -124,11 +124,15 @@ for (primitive.attributes.items) |attribute| {
 
 ## Install
 
-Note: **Zig 0.11.x is required.**
+Note: **Zig 0.15.1 is required.**
+
+```sh
+zig fetch --save git+https://github.com/kooparse/zgltf
+```
 
 ```zig
-const zgltf = @import("path-to-zgltf/build.zig");
-exe.addModule("zgltf", zgltf.module(b));
+const zgltf = b.dependency("zgltf", .{});
+exe.addModule("zgltf", zgltf.module("zgltf"));
 ```
 
 ## Features

--- a/build.zig
+++ b/build.zig
@@ -4,19 +4,19 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("zgltf", .{
-        .root_source_file = b.path("src/main.zig"),
+    const mod = b.addModule("zgltf", .{
+        .root_source_file = b.path("src/zgltf.zig"),
+        .target = target,
+        .optimize = optimize,
     });
 
-    var tests = b.addTest(.{
-        .root_module = b.addModule("main", .{
-            .root_source_file = b.path("src/main.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
+    const tests = b.addTest(.{
+        .root_module = mod,
     });
     b.installArtifact(tests);
 
+    var run_tests = b.addRunArtifact(tests);
+
     const test_step = b.step("test", "Run tests");
-    test_step.dependOn(&tests.step);
+    test_step.dependOn(&run_tests.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,8 @@
 .{
     .name = .zgltf,
-    .fingerprint = 0x7dfe8a1202907eb1,
     .version = "0.1.0",
+    .fingerprint = 0x7dfe8a1202907eb1,
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{},
     .paths = .{
         ".github",

--- a/src/types.zig
+++ b/src/types.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const Gltf = @import("main.zig");
+const Gltf = @import("Gltf.zig");
 const pi = std.math.pi;
 const panic = std.debug.panic;
 const json = @import("std").json;

--- a/src/zgltf.zig
+++ b/src/zgltf.zig
@@ -1,0 +1,5 @@
+pub const Gltf = @import("Gltf.zig");
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}


### PR DESCRIPTION
this PR places the main type in `Gltf.zig` and exports it from `zgltf.zig`.

before

```zig
const Gltf = @import("zgltf");
// error messages call the type `main`
```

after

```zig
const Gltf = @import("zgltf").Gltf;
// error messages call the type `Gltf`
```

this improves the debugging experience and follows Zig naming conventions.

I also fixed the test step, which was not actually running the tests.