### PR TITLE
fix: use array indexing syntax for buffer_views in Accessor.iterator

### DIFF
--- a/src/types.zig
+++ b/src/types.zig
@@ -124,7 +124,7 @@ pub const Accessor = struct {
             panic("Accessors without buffer_view are not supported yet.", .{});
         }
 
-        const buffer_view = gltf.data.buffer_views.items[accessor.buffer_view.?];
+        const buffer_view = gltf.data.buffer_views[accessor.buffer_view.?];
 
         const comp_size = @sizeOf(T);
         const offset = (accessor.byte_offset + buffer_view.byte_offset) / comp_size;


### PR DESCRIPTION
gltf.data.buffer_views is no longer of type ArrayList, and accessing it using the items field will result in a compilation error.