### PR TITLE
Fix AccessorIterator stride calculation for tightly packed data

### DIFF
--- a/src/types.zig
+++ b/src/types.zig
@@ -118,10 +118,11 @@ pub const Accessor = struct {
         const buffer_view = gltf.data.buffer_views[accessor.buffer_view.?];
 
         const offset = (accessor.byte_offset + buffer_view.byte_offset) / @sizeOf(T);
-        const stride = if (buffer_view.byte_stride) |byte_stride| (byte_stride / @sizeOf(T)) else 1;
+        const datum_count: usize = accessor.type.componentCount();
+        // When byte_stride is null, data is tightly packed, so stride = datum_count
+        const stride = if (buffer_view.byte_stride) |byte_stride| (byte_stride / @sizeOf(T)) else datum_count;
 
         const total_count: usize = @intCast(accessor.count);
-        const datum_count: usize = accessor.type.componentCount();
 
         const data: [*]const T = @ptrCast(@alignCast(binary.ptr));
 


### PR DESCRIPTION
Fixes a bug where an `AccessorIterator` without an explicit stride would return the incorrect data for multi-component types.

Example:

Assume we have the following vertex position buffer:
```
[ x0, y0, z0, x1, y1, z1, x2, y2, z2]
```
Previously, three calls to the `iterator.next()` would return:
```
[ x0, y0, z0]
[ y0, z0, x1]
[ z0, x1, y1]
```
With this fix it will now correctly return
```
[x0, y0, z0]
[x1, y1, z1]
[x2, y2, z2]
```