### PR TITLE
zig 0.16-dev.something update

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zgltf,
     .version = "0.1.0",
     .fingerprint = 0x7dfe8a1202907eb1,
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0-dev.2915+065c6e794",
     .dependencies = .{},
     .paths = .{
         ".github",

--- a/src/Gltf.zig
+++ b/src/Gltf.zig
@@ -1372,8 +1372,11 @@ test "gltf.parseGlb" {
     const allocator = std.testing.allocator;
     const expectEqualSlices = std.testing.expectEqualSlices;
 
+    const cwd = std.Io.Dir.cwd();
+    const io = std.testing.io;
+
     // This is the '.glb' file.
-    const glb_buf = try std.fs.cwd().readFileAllocOptions(allocator, "test-samples/box_binary/Box.glb", 512_000, null, .@"4", null);
+    const glb_buf = try cwd.readFileAllocOptions(io, "test-samples/box_binary/Box.glb", allocator, .limited(512_000), .@"4", null);
     defer allocator.free(glb_buf);
 
     var gltf = Gltf.init(allocator);
@@ -1414,12 +1417,15 @@ test "gltf.parseGlbTextured" {
     const allocator = std.testing.allocator;
     const expectEqualSlices = std.testing.expectEqualSlices;
 
+    const cwd = std.Io.Dir.cwd();
+    const io = std.testing.io;
+
     // This is the '.glb' file.
-    const glb_buf = try std.fs.cwd().readFileAllocOptions(
-        allocator,
+    const glb_buf = try cwd.readFileAllocOptions(
+        io,
         "test-samples/box_binary_textured/BoxTextured.glb",
-        512_000,
-        null,
+        allocator,
+        .limited(512_000),
         .@"4",
         null
     );
@@ -1430,10 +1436,11 @@ test "gltf.parseGlbTextured" {
 
     try gltf.parseGlb(glb_buf);
 
-    const test_to_check = try std.fs.cwd().readFileAlloc(
-        allocator,
+    const test_to_check = try cwd.readFileAlloc(
+        io,
         "test-samples/box_binary_textured/test.png",
-        512_000
+        allocator,
+        .limited(512_000),
     );
     defer allocator.free(test_to_check);
 
@@ -1448,11 +1455,15 @@ test "gltf.parse" {
 
     // This is the '.gltf' file, a json specifying what information is in the
     // model and how to retrieve it inside binary file(s).
-    const buf = try std.fs.cwd().readFileAllocOptions(
-        allocator,
+
+    const cwd = std.Io.Dir.cwd();
+    const io = std.testing.io;
+
+    const buf = try cwd.readFileAllocOptions(
+        io,
         "test-samples/rigged_simple/RiggedSimple.gltf",
-        512_000,
-        null,
+        allocator,
+        .limited(512_000),
         .@"4",
         null
     );
@@ -1488,11 +1499,14 @@ test "gltf.parse (cameras)" {
     const allocator = std.testing.allocator;
     const expectEqual = std.testing.expectEqual;
 
-    const buf = try std.fs.cwd().readFileAllocOptions(
-        allocator,
+    const cwd = std.Io.Dir.cwd();
+    const io = std.testing.io;
+
+    const buf = try cwd.readFileAllocOptions(
+        io,
         "test-samples/cameras/Cameras.gltf",
-        512_000,
-        null,
+        allocator,
+        .limited(512_000),
         .@"4",
         null
     );
@@ -1527,25 +1541,30 @@ test "gltf.getDataFromBufferView" {
     const allocator = std.testing.allocator;
     const expectEqualSlices = std.testing.expectEqualSlices;
 
-    const buf = try std.fs.cwd().readFileAllocOptions(
-        allocator,
+    const cwd = std.Io.Dir.cwd();
+    const io = std.testing.io;
+
+    const buf = try cwd.readFileAllocOptions(
+        io,
         "test-samples/box/Box.gltf",
-        512_000,
-        null,
+        allocator,
+        .limited(512_000),
         .@"4",
         null
     );
     defer allocator.free(buf);
 
     // This is the '.bin' file containing all the gltf underneath data.
-    const binary = try std.fs.cwd().readFileAllocOptions(
-        allocator,
+
+
+    const binary = try cwd.readFileAllocOptions(
+        io,
         "test-samples/box/Box0.bin",
-        5_000_000,
-        null,
+        allocator,
+        .limited(5_000_000),
         // From gltf spec, data from BufferView should be 4 bytes aligned.
         .@"4",
-        null,
+        null
     );
     defer allocator.free(binary);
 
@@ -1586,11 +1605,14 @@ test "gltf.parse (lights)" {
     const expect = std.testing.expect;
     const expectEqual = std.testing.expectEqual;
 
-    const buf = try std.fs.cwd().readFileAllocOptions(
-        allocator,
+    const cwd = std.Io.Dir.cwd();
+    const io = std.testing.io;
+
+    const buf = try cwd.readFileAllocOptions(
+        io,
         "test-samples/khr_lights_punctual/Lights.gltf",
-        512_000,
-        null,
+        allocator,
+        .limited(512_000),
         .@"4",
         null
     );


### PR DESCRIPTION
Update tests to use Zig's 0.16-dev std.Io API

The function in Zig 0.15.2:
```zig
pub fn readFileAllocOptions( 
   self: Dir, 
   allocator: mem.Allocator,
   file_path: []const u8, max_bytes: usize, 
   size_hint: ?usize, 
   comptime alignment: std.mem.Alignment,
   comptime optional_sentinel: ?u8,
)
```
changed in Zig 0.16-dev to:
```zig
pub fn readFileAllocOptions(
   dir: Dir,
   io: Io,
   sub_path: []const u8,
   gpa: Allocator,
   limit: Io.Limit,
   comptime alignment: std.mem.Alignment,
   comptime sentinel: ?u8, 
)
```

(same applies to `readFileAlloc`)

- ```cwd``` is now obtained via ```std.Io.Dir.cwd()```
- ```io: std.Io``` is provided by ```std.testing.io```
- ```max_bytes``` is replaced with ```limit: std.Io.Limit```
  - use ```std.Io.Limit.limited(max_bytes)```
- ```size_hint``` has been removed
- remaining parameters are unchanged

The examples in ```README.md``` also need to be updated to use the new ```std.Io``` API